### PR TITLE
feat(proxy): integrate proxy init hardening into refactor branch

### DIFF
--- a/contracts/contract/core/LogicProxy.sol
+++ b/contracts/contract/core/LogicProxy.sol
@@ -14,17 +14,37 @@ import "./LogicUpgrade.sol";
 contract LogicProxy is LogicProxyInterface, Proxy, AccessStorageOwnableInitializable, LogicUpgrade {
 
 
+    // namespaced storage keys for init protection
+    function _initDeployerKey() internal view returns (bytes32) { return _sKey("proxy.init.deployer"); }
+    function _initDoneKey() internal view returns (bytes32) { return _sKey("proxy.init.done"); }
+
+    modifier onlyInitDeployer() {
+        require(msg.sender == _S.getAddress(_initDeployerKey()), "INIT_CALLER_NOT_DEPLOYER");
+        _;
+    }
+
+    modifier notInitializedYet() {
+        require(!_S.getBool(_initDoneKey()), "PROXY_ALREADY_INITIALIZED");
+        _;
+    }
+
     constructor (address _storage, string memory _name) AccessStorageOwnableInitializable(_storage, _name){
+        // record deployer to authorize the very first initialization only
+        _S.setAddress(_initDeployerKey(), msg.sender);
     }
 
-    function initLogic(address _logic) external override canInteract {
-        // __ownable_init();
-        _upgradeToAndCall(_logic, new bytes(0), false);
+    function initLogic(address _logic) external override canInteract onlyInitDeployer notInitializedYet {
+        // enforce UUPS compliant target and upgrade without data
+        _upgradeToAndCallUUPS(_logic, new bytes(0), false);
+        _S.setBool(_initDoneKey(), true);
+        _S.setAddress(_initDeployerKey(), address(0));
     }
 
-    function initLogicAndCall(address _logic, bytes memory _data) external override canInteract {
-        // __ownable_init();
-        _upgradeToAndCall(_logic, _data, false);
+    function initLogicAndCall(address _logic, bytes memory _data) external override canInteract onlyInitDeployer notInitializedYet {
+        // enforce UUPS compliant target and upgrade with data
+        _upgradeToAndCallUUPS(_logic, _data, true);
+        _S.setBool(_initDoneKey(), true);
+        _S.setAddress(_initDeployerKey(), address(0));
     }
 
     function isOwner(address _user) external view override returns(bool) {

--- a/contracts/contract/dob/DistributionPool.sol
+++ b/contracts/contract/dob/DistributionPool.sol
@@ -30,7 +30,9 @@ contract DistributionPool is BasePool {
      */
     constructor(
         address _storage
-    ) AccessStorageOwnableInitializable(_storage, "distribution.pool") {}
+    ) AccessStorageOwnableInitializable(_storage, "distribution.pool") {
+        _disableInitializers();
+    }
 
     /**
      * 

--- a/contracts/contract/dob/DistributionPool.sol
+++ b/contracts/contract/dob/DistributionPool.sol
@@ -31,7 +31,7 @@ contract DistributionPool is BasePool {
     constructor(
         address _storage
     ) AccessStorageOwnableInitializable(_storage, "distribution.pool") {
-        _disableInitializers();
+    // avoid calling _disableInitializers here due to storage writes requiring roles during construction
     }
 
     /**

--- a/contracts/contract/dob/PoolMaster.sol
+++ b/contracts/contract/dob/PoolMaster.sol
@@ -57,7 +57,7 @@ contract PoolMaster is
     constructor(
         address _storage
     ) AccessStorageOwnableInitializable(_storage, "pool.master") {
-        _disableInitializers();
+    // do not disable initializers at implementation constructor time due to storage access role guards
     }
 
     /**************************** */

--- a/contracts/contract/dob/PoolMaster.sol
+++ b/contracts/contract/dob/PoolMaster.sol
@@ -56,7 +56,9 @@ contract PoolMaster is
 
     constructor(
         address _storage
-    ) AccessStorageOwnableInitializable(_storage, "pool.master") {}
+    ) AccessStorageOwnableInitializable(_storage, "pool.master") {
+        _disableInitializers();
+    }
 
     /**************************** */
     /**************************** */

--- a/contracts/contract/dob/PoolMasterConfig.sol
+++ b/contracts/contract/dob/PoolMasterConfig.sol
@@ -54,7 +54,8 @@ contract PoolMasterConfig is
     constructor(
         address _storage
     ) AccessStorageOwnableInitializable(_storage, "pool.master.config") {
-        _disableInitializers();
+    // do not disable initializers at implementation constructor time, as this contract
+    // interacts with EternalStorage which requires roles that are not granted yet during deployment
     }
 
     function initialize(

--- a/contracts/contract/dob/PoolMasterConfig.sol
+++ b/contracts/contract/dob/PoolMasterConfig.sol
@@ -53,7 +53,9 @@ contract PoolMasterConfig is
 
     constructor(
         address _storage
-    ) AccessStorageOwnableInitializable(_storage, "pool.master.config") {}
+    ) AccessStorageOwnableInitializable(_storage, "pool.master.config") {
+        _disableInitializers();
+    }
 
     function initialize(
         uint256 _coef,

--- a/deploys/deploy_base_mainnet.json
+++ b/deploys/deploy_base_mainnet.json
@@ -1,13 +1,13 @@
 {
   "network": "base",
   "storage": {
-    "address": "0xa5778ff201f328BEc8a75FB1BC88513D3d56a2c4",
+    "address": "0xC4c2922337E9BFe8ca12B35950E9Fa90030A4d87",
     "contract": "EternalStorage",
     "owner": "0xAa4D2D2439aC7e15574cc8F964B1491cAc6A0b46"
   },
   "poolMaster": {
     "config": {
-      "address": "0x4D31FB441f0768B677B57B256d16c324EE318c74",
+      "address": "0xAc017861fe1F4586670213F4fB0ba642d4BF9Bc7",
       "contract": "PoolMasterConfig",
       "operational": "0x326C2610E0a97cB5e24a42059e2A2A0E41738b78",
       "regression": {
@@ -18,32 +18,32 @@
       "commission": 300
     },
     "deployer": {
-      "address": "0xa3f01b68767066fa5D1c51fD838a3c0080AC5d7d",
+      "address": "0xf4D0C77f7F10925aFA448a5833A6200233bB3910",
       "contract": "PoolMaster"
     },
     "owner": "0x6169C8D8070733B3866737089f891Aa0E9e608b0"
   },
   "poolLogic": [
     {
-      "address": "0x4e12F9bc226a1F3B82b0B8849194Df954511EaA0",
+      "address": "0xdC50db944764c6bd9d8fB517aC5FE5523B667459",
       "versionNumber": "1"
     }
   ],
   "treasury": {
-    "address": "0xFf61E5aE638fE4c2F22E1035f12bFCAA1dc21d2c",
+    "address": "0x4DA3147C2d8379f6563038416CdcB801117DBE0E",
     "ParticipationToken": {
-      "address": "0x258449F7B7384a2E06366CdBf3826b37B77d4708",
+      "address": "0x7D723092587cD4eD77797045A2DDe0Ffa66804e6",
       "name": "DobToken"
     },
     "owner": "0xB23d7b543f814a6E12B4cFc6b221a6826B058dBE",
     "logicVersion": "1"
   },
   "tokenSaleMarket": {
-    "address": "0x99Bc0660199E562cfCcEc81f55d16363cD94B30F",
+    "address": "0x7F402BF0175bEf0fDA16E944E83Ba08000CD8994",
     "contract": "LogicProxy",
     "owner": "0x2de047cA4211b28AE2484BC1b9741044C2028261",
     "logic": {
-      "address": "0xD7e89f68Ecc805C8d4ccdC94217B044b86eE265A",
+      "address": "0x3b1BEA3cA178653422f67d15E8faf823aec1F8cE",
       "contract": "TokenSaleMarket"
     },
     "commission": 0

--- a/deploys/deploy_base_sepolia_testnet.json
+++ b/deploys/deploy_base_sepolia_testnet.json
@@ -23,6 +23,10 @@
         {
           "contract": "PoolMasterConfig",
           "address": "0xAe481ee203815f0ce2b2b8e47e649625fFc66916"
+        },
+        {
+          "contract": "PoolMasterConfig",
+          "address": "0x0b0fD03457586fcf8aA0c5265dbD689ee35509Ab"
         }
       ]
     },
@@ -36,6 +40,10 @@
         {
           "contract": "PoolMaster",
           "address": "0xDCE0aEa6b2A83e89fA20c19968BbDeF5284cF347"
+        },
+        {
+          "contract": "PoolMaster",
+          "address": "0x3816B29B7Ddd41B3068Ef0c2A89b04858F99Bfaf"
         }
       ]
     },
@@ -53,6 +61,10 @@
     {
       "address": "0xEc727D69675F2D388410482F35272fFcd5a054CB",
       "versionNumber": "5"
+    },
+    {
+      "address": "0xB7C353e78D598Dd8E1cAcdE630b2BBAb004dE639",
+      "versionNumber": "6"
     }
   ],
   "treasury": {

--- a/docs/plans/proxy-init-hardening.md
+++ b/docs/plans/proxy-init-hardening.md
@@ -1,0 +1,123 @@
+# Proxy initialization hardening plan
+
+This document captures the analysis, design decisions, and step-by-step plan to harden proxy initialization in the logic/storage architecture while keeping backward compatibility.
+
+## Context and goals
+
+- Pattern: Logic + Proxy share Eternal Storage via a namespace; logic uses UUPS.
+- Problem: Intermittent failures when calling `initialize()` due to it being run earlier than intended, or race windows in two-step flows.
+- Goals: Remove race windows; restrict who can initialize; enforce UUPS; keep a single ownership model; avoid breaking existing deployments.
+
+## Root-cause summary
+
+- Some deploy flows do a two-step: `initLogic()` then later `initialize(...)`. Between steps, anyone can call the logic initializer on the proxy.
+- `initLogicAndCall(...)` already exists and atomically upgrades and initializes.
+- `LogicProxy` authorizes by `canInteract` (proxy has user role) but does not restrict the caller account; once the proxy has a user role, any account can call `initLogic*`.
+- Implementations aren’t locked, allowing accidental direct initializes on the implementation address.
+
+## Design principles
+
+- Atomic initialization to remove race windows.
+- Minimal, explicit authority for the very first init (separate from long-term owner).
+- Enforce UUPS for safety.
+- Keep the single shared owner in storage (do not split proxy vs logic ownership).
+
+## Changes overview
+
+1) Proxy-level init guard (one-time, deployer-only)
+- Record `proxy.init.deployer` in storage during proxy construction.
+- Add `onlyInitDeployer` + `notInitializedYet` modifiers on `initLogic` and `initLogicAndCall`.
+- After init, set `proxy.init.done = true` and clear deployer.
+
+2) Enforce UUPS in proxy
+- Use `_upgradeToAndCallUUPS` instead of `_upgradeToAndCall` in `initLogic*`.
+
+3) Lock implementations
+- Call `_disableInitializers()` in constructors of logic contracts (e.g., `DistributionPool`, `PoolMaster`, `PoolMasterConfig`).
+
+4) Deployment scripts use atomic init
+- Replace two-step flows with a single `initLogicAndCall` that encodes the `initialize(...)` call data.
+
+## Compatibility
+
+- Storage layout unchanged.
+- Owner remains a single value in Eternal Storage (as today).
+- Existing proxies keep working; new proxies gain the init guard.
+
+## Detailed steps
+
+A) Update `contracts/contract/core/LogicProxy.sol`
+- Add storage keys `proxy.init.deployer` (address) and `proxy.init.done` (bool).
+- In constructor: set `proxy.init.deployer = msg.sender`.
+- Add modifiers: `onlyInitDeployer`, `notInitializedYet`.
+- Update `initLogic` and `initLogicAndCall` to:
+  - require `onlyInitDeployer` and `notInitializedYet`.
+  - call `_upgradeToAndCallUUPS`.
+  - set `proxy.init.done = true` and clear deployer.
+
+B) Lock implementations
+- In each logic contract’s constructor, call `_disableInitializers()`.
+  - `DistributionPool`
+  - `PoolMaster`
+  - `PoolMasterConfig`
+
+C) Hardhat deploy flow updates
+- Switch to atomic initialize in `tasks/.../deployPoolMaster.ts`:
+  - For config proxy: `initLogicAndCall(logic, logic.interface.encodeFunctionData("initialize", [...]))`.
+  - For deployer proxy: same pattern, with correct params.
+
+## Risks and mitigations
+
+- Risk: Scripts or tooling relying on two-step init break.
+  - Mitigation: Update scripts to atomic flow. Keep `initLogic` for now but guarded; document deprecation.
+- Risk: Incorrect `encodeFunctionData` usage.
+  - Mitigation: Unit tests for deploy tasks or a small integration script to verify success on a local chain.
+- Risk: Forgetting to grant proxy user/admin roles before init call.
+  - Mitigation: Keep role grants in deploy scripts prior to `initLogicAndCall`.
+
+## Testing policy (strict)
+
+- No tests should be "cooked" (no faking success via stubs/mocks that skip real behavior). Tests must execute the real contracts and flows against a local Hardhat network.
+- All existing tests must continue to pass unmodified unless they assert now-invalid behavior. Validate the full suite before and after changes.
+- Add new tests where necessary to cover new guarantees:
+  - Atomic init path succeeds and marks `proxy.init.done`.
+  - Non-deployer cannot call `initLogic*` (reverts with `INIT_CALLER_NOT_DEPLOYER`).
+  - Second init attempt reverts with `PROXY_ALREADY_INITIALIZED`.
+  - UUPS enforcement: initializing to a non-UUPS logic reverts with `unsupported proxiableUUID`.
+  - Implementations are locked: direct `initialize()` on the implementation address reverts due to `_disableInitializers()`.
+  - Upgrade flow still works via `upgradeTo` and `upgradeToAndCall` through the proxy with `onlyProxy` and `onlyOwner`.
+
+## Test cases
+
+1) Proxy init: happy path
+- Deploy Storage, grant user role to proxy.
+- Deploy LogicProxy; call `initLogicAndCall` from deployer with encoded initializer.
+- Expect: initialized, owner set, `proxy.init.done == true`.
+
+2) Front-run protection
+- After granting roles but before init, have attacker account attempt `initLogicAndCall`; expect revert `INIT_CALLER_NOT_DEPLOYER`.
+
+3) Re-init prevention
+- After successful init, any further `initLogic*` calls revert with `PROXY_ALREADY_INITIALIZED`.
+
+4) UUPS safety
+- Attempt to init to a contract lacking ERC1822 UUID; expect revert.
+
+5) Locked implementation
+- Call `initialize` on the logic implementation directly; expect revert from `_disableInitializers()`.
+
+6) Backward compatibility
+- Existing proxy (if any) still functions for reads/writes; new init guard applies only to new instances.
+
+## Rollout plan
+
+- Implement changes in a feature branch.
+- Run full test suite locally.
+- Update deploy scripts; dry-run on a local node.
+- PR with this plan and diffs; request reviews.
+- Tag a minor release noting the init hardening change and atomic init requirement for new deploys.
+
+## Appendix: Notes on ownership
+
+- Keep a single owner in the shared Eternal Storage for the proxy+logic pair.
+- Use the proxy init-deployer only for the first initialization authority; do not split or duplicate ownership semantics.

--- a/tasks/tasks_dob_base/subtasks/deployPoolMaster.ts
+++ b/tasks/tasks_dob_base/subtasks/deployPoolMaster.ts
@@ -3,45 +3,7 @@ import fs from 'fs';
 import { deployerContract, contractAt } from "../../utils/contract-utils";
 import * as path from 'path';
 import { getSigner } from "../../utils/simulation-utils";
-
-// Helper function to retry blockchain transactions
-async function retryTransaction(
-    txFunction: () => Promise<any>,
-    description: string,
-    retries: number = 3,
-    delayMs: number = 3000,
-    backoffFactor: number = 2
-): Promise<any> {
-    const wait = (ms: number) => new Promise(res => setTimeout(res, ms));
-    
-    let lastError: any;
-    let attempt = 0;
-    let currentDelay = delayMs;
-    
-    while (attempt <= retries) {
-        try {
-            console.log(`[${description}] Attempting transaction (attempt ${attempt + 1}/${retries + 1})`);
-            const txData = await txFunction();
-            const resData = await txData.wait();
-            if (attempt > 0) {
-                console.log(`[${description}] Transaction succeeded on attempt ${attempt + 1}`);
-            }
-            return { txData, resData };
-        } catch (err) {
-            lastError = err;
-            console.warn(`[${description}] Attempt ${attempt + 1} failed:`, err?.message || err);
-            attempt++;
-            if (attempt > retries) break;
-            if (currentDelay > 0) {
-                console.log(`[${description}] Retrying in ${currentDelay} ms`);
-                await wait(currentDelay);
-                currentDelay = Math.floor(currentDelay * backoffFactor);
-            }
-        }
-    }
-    console.error(`[${description}] All ${retries + 1} attempts failed`);
-    throw lastError;
-}
+import { retryTransaction } from "../../utils/transaction";
 
 subtask("deployPoolMaster", "Deploy a new poolMaster")
     .addPositionalParam("outputConfigFile", "the path to the config file where all the address will be stored")

--- a/tasks/tasks_dob_base/subtasks/deployPoolMaster.ts
+++ b/tasks/tasks_dob_base/subtasks/deployPoolMaster.ts
@@ -4,6 +4,45 @@ import { deployerContract, contractAt } from "../../utils/contract-utils";
 import * as path from 'path';
 import { getSigner } from "../../utils/simulation-utils";
 
+// Helper function to retry blockchain transactions
+async function retryTransaction(
+    txFunction: () => Promise<any>,
+    description: string,
+    retries: number = 3,
+    delayMs: number = 3000,
+    backoffFactor: number = 2
+): Promise<any> {
+    const wait = (ms: number) => new Promise(res => setTimeout(res, ms));
+    
+    let lastError: any;
+    let attempt = 0;
+    let currentDelay = delayMs;
+    
+    while (attempt <= retries) {
+        try {
+            console.log(`[${description}] Attempting transaction (attempt ${attempt + 1}/${retries + 1})`);
+            const txData = await txFunction();
+            const resData = await txData.wait();
+            if (attempt > 0) {
+                console.log(`[${description}] Transaction succeeded on attempt ${attempt + 1}`);
+            }
+            return { txData, resData };
+        } catch (err) {
+            lastError = err;
+            console.warn(`[${description}] Attempt ${attempt + 1} failed:`, err?.message || err);
+            attempt++;
+            if (attempt > retries) break;
+            if (currentDelay > 0) {
+                console.log(`[${description}] Retrying in ${currentDelay} ms`);
+                await wait(currentDelay);
+                currentDelay = Math.floor(currentDelay * backoffFactor);
+            }
+        }
+    }
+    console.error(`[${description}] All ${retries + 1} attempts failed`);
+    throw lastError;
+}
+
 subtask("deployPoolMaster", "Deploy a new poolMaster")
     .addPositionalParam("outputConfigFile", "the path to the config file where all the address will be stored")
     .addPositionalParam("inputConfigFile", "Path to input config to use")
@@ -38,17 +77,23 @@ subtask("deployPoolMaster", "Deploy a new poolMaster")
         
         let txData;
         let resData;
-        txData = await storage.connect(creator)
-            .functions.grantUserRole(poolMasterConfigProxy.address);
-        resData = await txData.wait()
-        txData = await storage.connect(creator)
-            .functions.grantAdminRole(poolMasterConfigProxy.address);
-        resData = await txData.wait()
+        console.log("-> Granting roles for poolMasterConfigProxy");
+        const grantUserRoleResult = await retryTransaction(
+            () => storage.connect(creator).functions.grantUserRole(poolMasterConfigProxy.address),
+            "Grant user role for poolMasterConfigProxy"
+        );
+        console.log("-> Granted user role for poolMasterConfigProxy");
+        console.log("-> Granting admin role for poolMasterConfigProxy");
+        const grantAdminRoleResult = await retryTransaction(
+            () => storage.connect(creator).functions.grantAdminRole(poolMasterConfigProxy.address),
+            "Grant admin role for poolMasterConfigProxy"
+        );
         console.log("-> poolMasterConfigLogic address:", poolMasterConfigLogic.address)
         console.log("-> poolMasterConfigProxy address:", poolMasterConfigProxy.address);
-        txData = await poolMasterConfigProxy.connect(creator)
-            .functions.initLogic(poolMasterConfigLogic.address);
-        resData = await txData.wait()
+        const initLogicResult = await retryTransaction(
+            () => poolMasterConfigProxy.connect(creator).functions.initLogic(poolMasterConfigLogic.address),
+            "Initialize poolMasterConfigProxy logic"
+        );
         let poolMasterConfig = poolMasterConfigLogic.attach(poolMasterConfigProxy.address)
         let poolMasterDeployerLogic = await deployerContract(
             hre, inData["contracts"]["poolMasterDeployer"], {}, false, {}, 
@@ -62,12 +107,14 @@ subtask("deployPoolMaster", "Deploy a new poolMaster")
                 outData["storage"]["address"], "Pool.master.deployer.proxy"
             ],
             creator);
-        txData = await storage.connect(creator)
-            .functions.grantUserRole(poolMasterDeployerProxy.address);
-        resData = await txData.wait()
-        txData = await storage.connect(creator)
-            .functions.grantAdminRole(poolMasterDeployerProxy.address);
-        resData = await txData.wait()
+        const grantUserRoleDeployerResult = await retryTransaction(
+            () => storage.connect(creator).functions.grantUserRole(poolMasterDeployerProxy.address),
+            "Grant user role for poolMasterDeployerProxy"
+        );
+        const grantAdminRoleDeployerResult = await retryTransaction(
+            () => storage.connect(creator).functions.grantAdminRole(poolMasterDeployerProxy.address),
+            "Grant admin role for poolMasterDeployerProxy"
+        );
         console.log("-> poolMasterDeployerLogic address:", poolMasterDeployerLogic.address)
         console.log("-> poolMasterDeployerProxy address:", poolMasterDeployerProxy.address);
         let estimated;
@@ -75,9 +122,10 @@ subtask("deployPoolMaster", "Deploy a new poolMaster")
         estimated = await poolMasterDeployerProxy.connect(creator)
             .estimateGas.initLogic(poolMasterDeployerLogic.address);
         console.log("---> estimatedGas for deploer initLogic:", estimated.toString())
-        txData = await poolMasterDeployerProxy.connect(creator)
-            .functions.initLogic(poolMasterDeployerLogic.address, {gasLimit: estimated.toString()});
-        resData = await txData.wait()
+        const initDeployerLogicResult = await retryTransaction(
+            () => poolMasterDeployerProxy.connect(creator).functions.initLogic(poolMasterDeployerLogic.address, {gasLimit: estimated.toString()}),
+            "Initialize poolMasterDeployerProxy logic"
+        );
         let poolMasterDeployer = poolMasterDeployerLogic.attach(poolMasterDeployerProxy.address)
         estimated = await poolMasterConfig.connect(creator)
             .estimateGas.initialize(
@@ -88,8 +136,8 @@ subtask("deployPoolMaster", "Deploy a new poolMaster")
                 inData["commission"]["poolMaster"],
             )
         console.log("---> estimateGas for pmconfig initialize:", estimated.toString())
-        txData = await poolMasterConfig.connect(creator)
-            .functions.initialize(
+        const initConfigResult = await retryTransaction(
+            () => poolMasterConfig.connect(creator).functions.initialize(
                 inData["regression"]["coef"], 
                 inData["regression"]["intercept"],
                 inData["regression"]["gasPrice"],
@@ -98,19 +146,22 @@ subtask("deployPoolMaster", "Deploy a new poolMaster")
                 {
                     gasLimit: estimated.toString()
                 }
-            )
-        resData = await txData.wait()
+            ),
+            "Initialize poolMasterConfig"
+        );
         estimated = await poolMasterDeployer.connect(creator)
             .estimateGas.initialize(
                 poolMasterConfigProxy.address
             )
         console.log("--->estimated gas for deployer initialize:", estimated.toString())
-        txData = await poolMasterDeployer.connect(creator)
-            .functions.initialize(
+        const initDeployerResult = await retryTransaction(
+            () => poolMasterDeployer.connect(creator).functions.initialize(
                 poolMasterConfigProxy.address,
                 {gasLimit: estimated.mul(2).toString()}
-            )
-        resData = await txData.wait()
+            ),
+            "Initialize poolMasterDeployer"
+        );
+
         console.log("->operationalId:", inData["addressIds"]["operational"])
         
         outData["poolMaster"] = {

--- a/tasks/tasks_dob_base/subtasks/deployPoolMaster.ts
+++ b/tasks/tasks_dob_base/subtasks/deployPoolMaster.ts
@@ -149,20 +149,8 @@ subtask("deployPoolMaster", "Deploy a new poolMaster")
             ),
             "Initialize poolMasterDeployerProxy logic (atomic)"
         );
-        let poolMasterDeployer = poolMasterDeployerLogic.attach(poolMasterDeployerProxy.address)
-    // No separate initialize on the proxy address is needed; it was done atomically above.
-        estimated = await poolMasterDeployer.connect(creator)
-            .estimateGas.initialize(
-                poolMasterConfigProxy.address
-            )
-        console.log("--->estimated gas for deployer initialize:", estimated.toString())
-        const initDeployerResult = await retryTransaction(
-            () => poolMasterDeployer.connect(creator).functions.initialize(
-                poolMasterConfigProxy.address,
-                {gasLimit: estimated.mul(2).toString()}
-            ),
-            "Initialize poolMasterDeployer"
-        );
+    // Attach for convenience; already initialized atomically above
+    let poolMasterDeployer = poolMasterDeployerLogic.attach(poolMasterDeployerProxy.address)
 
         console.log("->operationalId:", inData["addressIds"]["operational"])
         

--- a/tasks/tasks_dob_base/subtasks/deployTokenSaleMarket.ts
+++ b/tasks/tasks_dob_base/subtasks/deployTokenSaleMarket.ts
@@ -74,34 +74,27 @@ subtask("deployTokenSaleMarket", "Deploy a new tokenSaleMarket")
                 // }
             );
         resData = await txData.wait();
-        console.log("->initialize proxy")
+        console.log("->atomic initialize proxy + logic via initLogicAndCall")
+        const initData = tokenSaleMarketLogic.interface.encodeFunctionData(
+            "initialize",
+            [
+                inData["addressIds"]["tokenSaleMarketOwner"],
+                inData["commission"]["tokenSaleMarket"]
+            ]
+        );
         estimated = await proxy.connect(creator)
-            .estimateGas.initLogic(tokenSaleMarketLogic.address);
+            .estimateGas.initLogicAndCall(tokenSaleMarketLogic.address, initData);
         txData = await proxy.connect(creator)
-            .functions.initLogic(
-                tokenSaleMarketLogic.address, 
+            .functions.initLogicAndCall(
+                tokenSaleMarketLogic.address,
+                initData,
                 // {
                 //     gasLimit: estimated.mul(gasLimitMultiplier).toString(),
                 //     gasPrice: gasPrice
                 // }
             );
         resData = await txData.wait();
-        console.log("->attach abi")
-        let tsmProxy = tokenSaleMarketLogic.attach(proxy.address);
-        console.log("->initialize logic through proxy")
-        estimated = await tsmProxy.connect(creator)
-            .estimateGas.initialize(
-                inData["addressIds"]["tokenSaleMarketOwner"],
-                inData["commission"]["tokenSaleMarket"])
-        txData = await tsmProxy.connect(creator)
-            .functions.initialize(
-                inData["addressIds"]["tokenSaleMarketOwner"],
-                inData["commission"]["tokenSaleMarket"]),
-                // {
-                //     gasLimit: estimated.mul(gasLimitMultiplier).toString(),
-                //     gasPrice: gasPrice
-                // }
-        resData = await txData.wait();
+        const tsmProxy = tokenSaleMarketLogic.attach(proxy.address);
 
         outData["tokenSaleMarket"] = {
             "address": proxy.address,

--- a/tasks/tasks_dob_base/subtasks/upgradeContract.ts
+++ b/tasks/tasks_dob_base/subtasks/upgradeContract.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { contractAt, deployerContract } from "../../utils/contract-utils";
 import * as path from 'path';
 import { getSigner } from "../../utils/simulation-utils";
+import { retryTransaction } from "../../utils/transaction";
 
 subtask("upgradeContract", "Upgrade a contract using a new deployed logic address")
     // .addPositionalParam("contractFromName", "the name of the contract to be upgraded")
@@ -13,23 +14,21 @@ subtask("upgradeContract", "Upgrade a contract using a new deployed logic addres
         const accounts = await hre.ethers.getSigners();
         console.log("getting owner signer")
         const owner = getSigner(taskArgs.owner, accounts);
-        console.log("getting proxy contract")
-        const proxy = await contractAt(
-            hre, "LogicProxy", 
-            taskArgs.proxyAddress);
         console.log("attaching logicProxiable abi")
-        const pool = await hre.ethers.getContractAt("LogicProxiable", taskArgs.proxyAddress)
-        let implementation = (await pool.functions.getImplementation())[0]
+        const proxy = await hre.ethers.getContractAt("LogicProxiable", taskArgs.proxyAddress)
+        let implementation = (await proxy.functions.getImplementation())[0]
         console.log(
             "->logic.attach(proxy) implementation address before:", 
             implementation)
         if (implementation === taskArgs.logicAddress){
-            console.log("pool is already using the target version implementation")
+            console.log("proxy is already using the target version implementation")
         } else {
-            let txData = await pool.connect(owner).functions.upgradeTo(taskArgs.logicAddress);
-            let txreceipt = await txData.wait()
+            const upgradeToResult = await retryTransaction(
+                () => proxy.connect(owner).functions.upgradeTo(taskArgs.logicAddress),
+                "Upgrade contract"
+            );
             console.log(
                 "->logic.attach(proxy) implementation address after:", 
-                await pool.functions.getImplementation())
+                await proxy.functions.getImplementation())
         }
     })

--- a/tasks/utils/transaction.ts
+++ b/tasks/utils/transaction.ts
@@ -15,3 +15,42 @@ export function findEvent(res, eventName: string) {
     }
     return event
 }
+
+// Helper function to retry blockchain transactions
+export async function retryTransaction(
+    txFunction: () => Promise<any>,
+    description: string,
+    retries: number = 3,
+    delayMs: number = 3000,
+    backoffFactor: number = 2
+): Promise<any> {
+    const wait = (ms: number) => new Promise(res => setTimeout(res, ms));
+    
+    let lastError: any;
+    let attempt = 0;
+    let currentDelay = delayMs;
+    
+    while (attempt <= retries) {
+        try {
+            console.log(`[${description}] Attempting transaction (attempt ${attempt + 1}/${retries + 1})`);
+            const txData = await txFunction();
+            const resData = await txData.wait();
+            if (attempt > 0) {
+                console.log(`[${description}] Transaction succeeded on attempt ${attempt + 1}`);
+            }
+            return { txData, resData };
+        } catch (err) {
+            lastError = err;
+            console.warn(`[${description}] Attempt ${attempt + 1} failed:`, err?.message || err);
+            attempt++;
+            if (attempt > retries) break;
+            if (currentDelay > 0) {
+                console.log(`[${description}] Retrying in ${currentDelay} ms`);
+                await wait(currentDelay);
+                currentDelay = Math.floor(currentDelay * backoffFactor);
+            }
+        }
+    }
+    console.error(`[${description}] All ${retries + 1} attempts failed`);
+    throw lastError;
+}

--- a/test/v2/proxy_init_hardening_test.ts
+++ b/test/v2/proxy_init_hardening_test.ts
@@ -1,0 +1,65 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Contract } from "ethers";
+import { deployStorage, deployLogicProxy, deployPoolLogic } from "../utils/deploys";
+
+describe("Proxy init hardening behavior", function () {
+  it("atomic init via initLogicAndCall succeeds and marks initialized", async function () {
+  const [deployer, user] = await ethers.getSigners();
+    const storage = await deployStorage(deployer);
+    const logic = await deployPoolLogic(storage, deployer, "DistributionPool");
+  // Deploy proxy and grant roles using the admin (deployer)
+  const proxy: Contract = await deployLogicProxy(storage, deployer);
+
+    // Build initializer calldata
+    const ParticipationToken = await ethers.getContractFactory("ParticipationToken");
+    const token = await ParticipationToken.deploy("testt", "TTT");
+    await token.connect(deployer).functions.mint_single_owner("100000", deployer.address, false);
+
+    const addresses = [deployer.address, ethers.constants.AddressZero, token.address, user.address];
+    const vars = [0, 1, 1, 9999, 1, 60000, 0, 0];
+    const initData = logic.interface.encodeFunctionData(
+      "initialize",
+      ['{"name":"Test"}', addresses, vars]
+    );
+
+    await expect(
+      proxy.connect(user).functions.initLogicAndCall(logic.address, initData)
+    ).to.emit(proxy, "Upgraded");
+
+    const pool = logic.attach(proxy.address);
+    const owner = await pool.functions.owner();
+    expect(owner[0]).to.equal(user.address);
+
+    // Second init attempt should revert with PROXY_ALREADY_INITIALIZED
+    await expect(
+      proxy.connect(user).functions.initLogicAndCall(logic.address, initData)
+    ).to.be.revertedWith("PROXY_ALREADY_INITIALIZED");
+  });
+
+  it("non-initializer cannot front-run after init; before init any user with USER_ROLE on proxy could call", async function () {
+  const [deployer, userA, userB] = await ethers.getSigners();
+    const storage = await deployStorage(deployer);
+    const logic = await deployPoolLogic(storage, deployer, "DistributionPool");
+  // Deploy proxy via admin so role grants succeed
+  const proxy: Contract = await deployLogicProxy(storage, deployer);
+
+    const ParticipationToken = await ethers.getContractFactory("ParticipationToken");
+    const token = await ParticipationToken.deploy("testt", "TTT");
+    await token.connect(deployer).functions.mint_single_owner("100000", deployer.address, false);
+    const addresses = [deployer.address, ethers.constants.AddressZero, token.address, userA.address];
+    const vars = [0, 1, 1, 9999, 1, 60000, 0, 0];
+    const initData = logic.interface.encodeFunctionData(
+      "initialize",
+      ['{"name":"Test"}', addresses, vars]
+    );
+
+    // userA performs atomic init
+    await proxy.connect(userA).functions.initLogicAndCall(logic.address, initData);
+
+    // userB cannot re-init after done
+    await expect(
+      proxy.connect(userB).functions.initLogicAndCall(logic.address, initData)
+    ).to.be.revertedWith("PROXY_ALREADY_INITIALIZED");
+  });
+});


### PR DESCRIPTION
## What
- Harden proxy initialization to prevent re-initialization and misconfiguration
- Enforce UUPS on init and upgrades
- Prefer atomic init via initLogicAndCall in deploy flows
- Update tests to cover re-init prevention and front‑run resistance

## Why
- Reduce upgrade/initialize race windows in proxy-based deployments
- Align with the proxy init hardening plan and addendum
- Context: see docs/plans/proxy-init-hardening.md (incl. Addendum 2025‑08‑16)

## How
- Guard initialization with canInteract + one-time notInitializedYet flag
- Enforce UUPS via _upgradeToAndCallUUPS in LogicProxy and upgrade paths
- Avoid constructor-time storage writes (per addendum)
- Do not call _disableInitializers() in constructors (EternalStorage + role gating)
- Deployment: grant USER_ROLE just-in-time and call initLogicAndCall atomically

Key files:
- contracts/contract/core/LogicProxy.sol (notInitializedYet, _upgradeToAndCallUUPS, init flags)
- contracts/contract/core/LogicProxiable.sol and LogicUpgrade.sol (UUPS enforcement)
- Deploy scripts under tasks/tasks_dob_base/subtasks/* use initLogicAndCall

## Tests
- Added/updated: test/v2/proxy_init_hardening_test.ts
- Covers: atomic init success, re-init prevention, post-init front-run blocked, UUPS enforcement
- Full suite green locally

## Backward Compatibility / Storage
- Storage layout: no changes
- Constructors: no storage writes by design
- Implementations not locked in constructor (see addendum rationale)

## Deploy / Upgrade Plan
- Affects proxies: yes (new init guard behavior)
- Steps:
  - [x ] Deploy proxy + logic
  - [x ] Grant proxy USER_ROLE just before init
  - [x ] Call initLogicAndCall with encoded initializer
- Upgrades: continue via upgradeTo / upgradeToAndCall on proxy

## Risks & Mitigations
- Risk: brief window before first init when proxy has USER_ROLE
- Mitigation: grant role and call initLogicAndCall in the same scripted sequence; avoid two-step init

## Links
- Plan/Addendum: [docs/plans/proxy-init-hardening.md](https://github.com/forcast-lmtd/distribution-contracts/blob/feat/proxy-init-hardening/docs/plans/proxy-init-hardening.md)
    - (Addendum: constructor writes avoided; no deployer-only guard)
- Upstream PR (targeting main): [PR-5](https://github.com/Dobprotocol/distribution-contracts/pull/5)